### PR TITLE
Enhance admin layouts UI 🚀

### DIFF
--- a/assets/css/admin-layouts.css
+++ b/assets/css/admin-layouts.css
@@ -26,4 +26,22 @@
 
 .acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout > .acfe-fc-placeholder {
     padding: 0 !important;
+    border-color: transparent !important;
+}
+
+.acf-field.acf-field-flexible-content[data-acfe-flexible-stylised-button="1"] > .acf-input > .acf-flexible-content:not(.empty) > .values {
+    opacity: 1;
+}
+
+.acf-field.acf-field-flexible-content[data-acfe-flexible-stylised-button="1"] > .acf-input > .acf-flexible-content:not(.empty) > .values:hover > .layout {
+    opacity: 0.65;
+}
+
+.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout:hover {
+    outline: 2px solid #444;
+    opacity: 1 !important;
+}
+
+.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout > .acf-fields {
+    border-color: transparent !important;
 }

--- a/assets/css/admin-layouts.css
+++ b/assets/css/admin-layouts.css
@@ -19,6 +19,13 @@
     border-radius: 5px;
 }
 
+/* Fix collection label display */
+.acfe-layout-title-text .pip_collection {
+    display: inline-block;
+    width: auto;
+    margin: auto 5px auto auto;
+}
+
 .acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout[data-layout] > .acf-fc-layout-controls {
     padding: 8px 10px;
     z-index: 2;

--- a/assets/css/admin-layouts.css
+++ b/assets/css/admin-layouts.css
@@ -15,6 +15,8 @@
 .acfe-layout-title-text:hover {
     color: #23282d;
     background: #F5F5F5;
+    padding: 0 0.25rem;
+    border-radius: 5px;
 }
 
 .acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout[data-layout] > .acf-fc-layout-controls {

--- a/assets/css/admin-layouts.css
+++ b/assets/css/admin-layouts.css
@@ -37,11 +37,11 @@
     opacity: 0.65;
 }
 
-.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout:hover {
+.acf-field.acf-field-flexible-content[data-acfe-flexible-stylised-button="1"] > .acf-input > .acf-flexible-content:not(.empty) > .values > .layout:hover {
     outline: 2px solid #444;
     opacity: 1 !important;
 }
 
-.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout > .acf-fields {
+.acf-field.acf-field-flexible-content[data-acfe-flexible-stylised-button="1"] > .acf-input > .acf-flexible-content:not(.empty) > .values > .layout > .acf-fields {
     border-color: transparent !important;
 }

--- a/assets/css/admin-layouts.css
+++ b/assets/css/admin-layouts.css
@@ -1,0 +1,27 @@
+.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout[data-layout],
+.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout[data-layout]:first-child {
+    margin-top: 0 !important;
+}
+
+.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout[data-layout].-collapsed > .acf-fc-layout-handle {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    right: 10px;
+    z-index: 1;
+}
+
+.acfe-layout-title-text,
+.acfe-layout-title-text:hover {
+    color: #23282d;
+    background: #F5F5F5;
+}
+
+.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout[data-layout] > .acf-fc-layout-controls {
+    padding: 8px 10px;
+    z-index: 2;
+}
+
+.acf-field-flexible-content[data-name="pip_flexible"] > .acf-input > .acf-flexible-content > .values > .layout > .acfe-fc-placeholder {
+    padding: 0 !important;
+}

--- a/includes/class-main.php
+++ b/includes/class-main.php
@@ -39,6 +39,7 @@ if ( !class_exists( 'PIP_Addon_Main' ) ) {
          */
         public function admin_assets() {
             wp_enqueue_script( 'pip-addon-layouts', PIP_ADDON_URL . 'assets/js/pip-addon-layouts.js', array( 'jquery' ), '', true );
+            wp_enqueue_style( 'pip-addon-layouts', PIP_ADDON_URL . 'assets/css/admin-layouts.css' );
         }
 
         /**


### PR DESCRIPTION
## Explanation

Due to recent 5.5 WP UI update, WYSIWYG (and ACF fields) are rendered inside a "Editor" metabox with a "editor" metabox title (like others metaboxes)
To fix UI display and therefor also enhance the UI (by removing mostly empty space), i made this PR subject to debate :)

## Changes

I added an admin stylesheet which put the handle as position absolute (to make it float over the layout itself) and added same color / background as acf icons.

## Video
[Video](https://www.loom.com/share/1d8793e4eb0844c09d3efbb8de22e379)

## Screenshots

### Layout collapsed
![pip-addon-admin-layouts1](https://user-images.githubusercontent.com/62112531/90124369-8f5c2100-dd60-11ea-8a82-3ab0cc6faa31.jpg)

### Hover layout collapsed
![pip-addon-admin-layouts2](https://user-images.githubusercontent.com/62112531/90124392-94b96b80-dd60-11ea-8b51-357081f07893.jpg)

### Hover layout collapsed handle
![pip-addon-admin-layouts3](https://user-images.githubusercontent.com/62112531/90124400-97b45c00-dd60-11ea-8a22-7e3641521293.jpg)

### Layout uncollapsed
![pip-addon-admin-layouts4](https://user-images.githubusercontent.com/62112531/90124332-823f3200-dd60-11ea-8f9b-60136f17e84c.jpg)